### PR TITLE
feat: add a TypeScript user code snippet

### DIFF
--- a/docs/zh/slate/walkthroughs/01-installing-slate.md
+++ b/docs/zh/slate/walkthroughs/01-installing-slate.md
@@ -46,6 +46,25 @@ const App = () => {
 }
 ```
 
+>如果你正在使用TypeScript，你还需要根据TypeScript文档使用ReactEditor来扩展Editor。下面的示例包括了本示例其余部分所需的自定义类型。
+
+```tsx
+// TypeScript 用户添加这一段代码
+import { BaseEditor } from 'slate'
+import { ReactEditor } from 'slate-react'
+
+type CustomElement = { type: 'paragraph'; children: CustomText[] }
+type CustomText = { text: string }
+
+declare module 'slate' {
+  interface CustomTypes {
+    Editor: BaseEditor & ReactEditor
+    Element: CustomElement
+    Text: CustomText
+  }
+}
+```
+
 当然我们没有渲染任何的东西，所以你不会看到任何变化。
 
 接下来我们要使用 `value` 创建一个状态:


### PR DESCRIPTION
嗨，亲爱的作者。我在阅读您的中文文档的时候，发现无法正常运行。于是我去看了英文文档，发现您的示例中缺少了typescript用户需要添加的必要声明的说明。如下所示：

[中文文档：](https://rain120.github.io/athena/zh/slate/walkthroughs/01-installing-slate.html)
![image](https://user-images.githubusercontent.com/48620706/123379120-3f74fa00-d5c0-11eb-8021-0ac66d242c00.png)

[英文文档：](https://docs.slatejs.org/walkthroughs/01-installing-slate)
![image](https://user-images.githubusercontent.com/48620706/123379185-57e51480-d5c0-11eb-8e66-a720cc62a339.png)

我冒昧的在您的文档中，加入了这一步骤。提交pr到了您的仓库。

感谢你为开源做出的贡献