### PR TITLE
修改了实战演练中例子Slate组件中value值已不可用的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 </div>
 
-## 😚 Welcome
+## 😚 Welcom
 
 Welcome to Here for the Chinese documentation.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 </div>
 
-## 😚 Welcom
+## 😚 Welcome
 
 Welcome to Here for the Chinese documentation.
 

--- a/docs/zh/slate/walkthroughs/01-installing-slate.md
+++ b/docs/zh/slate/walkthroughs/01-installing-slate.md
@@ -76,7 +76,7 @@ const initialValue = []
 const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
   // 渲染 Slate 上下文。
-  return <Slate editor={editor} value={initialValue} />
+  return <Slate editor={editor} initialValue={initialValue} />
 }
 ```
 
@@ -97,7 +97,7 @@ const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
   return (
     // 在上下文中添加一个可编辑的组件。
-    <Slate editor={editor} value={initialValue}>
+    <Slate editor={editor} initialValue={initialValue}>
       <Editable />
     </Slate>
   )
@@ -123,7 +123,7 @@ const App = () => {
   const [editor] = useState(() => withReact(createEditor()))
 
   return (
-    <Slate editor={editor} value={initialValue}>
+    <Slate editor={editor} initialValue={initialValue}>
       <Editable />
     </Slate>
   )


### PR DESCRIPTION
按照最新的官方文档，此处Slate组件中应该写为initiValue={initiValue}